### PR TITLE
Refactors PR #5733

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -314,11 +314,6 @@ private[spark] object SQLConf {
     defaultValue = Some(5 * 60),
     doc = "Timeout in seconds for the broadcast wait time in broadcast joins.")
 
-  val HIVE_WRITE_DATASOURCE_SCHEMA = booleanConf("spark.sql.hive.writeDataSourceSchema",
-    defaultValue = Some(true),
-    doc = "When true, will write the metastore information to Hive Metastore for " +
-      "Spark SQL DataSource Updating/Insertion, so Hive can access the Spark SQL data seamlessly.")
-
   // Options that control which operators can be chosen by the query planner.  These should be
   // considered hints and may be ignored by future versions of Spark SQL.
   val EXTERNAL_SORT = booleanConf("spark.sql.planner.externalSort",
@@ -467,8 +462,6 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
   private[spark] def verifyPartitionPath: Boolean = getConf(HIVE_VERIFY_PARTITION_PATH)
 
   private[spark] def metastorePartitionPruning: Boolean = getConf(HIVE_METASTORE_PARTITION_PRUNING)
-
-  private[spark] def writeSchemaToHiveMetastore = getConf(HIVE_WRITE_DATASOURCE_SCHEMA)
 
   private[spark] def externalSortEnabled: Boolean = getConf(EXTERNAL_SORT)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.hive
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable
 
 import com.google.common.base.Objects
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
@@ -57,51 +58,40 @@ private[hive] object HiveSerDe {
    * @param source Currently the source abbreviation can be one of the following:
    *               SequenceFile, RCFile, ORC, PARQUET, and case insensitive.
    * @param hiveConf Hive Conf
-   * @param returnDefaultFormat Will the default format returns if no assocated data source found.
-   *   The default input/output format is:
-   *     InputFormat:  org.apache.hadoop.mapred.TextInputFormat
-   *     OutputFormat: org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat
    * @return HiveSerDe associated with the specified source
    */
-  def sourceToSerDe(source: String, hiveConf: HiveConf, returnDefaultFormat: Boolean)
-  : Option[HiveSerDe] = {
-    val serde = if ("SequenceFile".equalsIgnoreCase(source)) {
-      HiveSerDe(
-        inputFormat = Option("org.apache.hadoop.mapred.SequenceFileInputFormat"),
-        outputFormat = Option("org.apache.hadoop.mapred.SequenceFileOutputFormat"))
-    } else if ("RCFile".equalsIgnoreCase(source)) {
-      HiveSerDe(
-        inputFormat = Option("org.apache.hadoop.hive.ql.io.RCFileInputFormat"),
-        outputFormat = Option("org.apache.hadoop.hive.ql.io.RCFileOutputFormat"),
-        serde = Option(hiveConf.getVar(HiveConf.ConfVars.HIVEDEFAULTRCFILESERDE)))
-    } else if ("ORC".equalsIgnoreCase(source) ||
-               "org.apache.spark.sql.hive.orc.DefaultSource" == source) {
-      HiveSerDe(
-        inputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"),
-        outputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"),
-        serde = Option("org.apache.hadoop.hive.ql.io.orc.OrcSerde"))
-    } else if ("PARQUET".equalsIgnoreCase(source) ||
-               "org.apache.spark.sql.parquet.DefaultSource" == source) {
-      HiveSerDe(
-        inputFormat =
-          Option("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"),
-        outputFormat =
-          Option("org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"),
-        serde =
-          Option("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"))
-    } else if (returnDefaultFormat) {
-      // return default file format
-      HiveSerDe(
-        inputFormat =
-          Option("org.apache.hadoop.mapred.TextInputFormat"),
-        outputFormat =
-          Option("org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat"))
-    } else {
-      // TODO we probably need to provide SerDe for the built-in format, like json.
-      null
+  def sourceToSerDe(source: String, hiveConf: HiveConf): Option[HiveSerDe] = {
+    val serdeMap = Map(
+      "sequencefile" ->
+        HiveSerDe(
+          inputFormat = Option("org.apache.hadoop.mapred.SequenceFileInputFormat"),
+          outputFormat = Option("org.apache.hadoop.mapred.SequenceFileOutputFormat")),
+
+      "rcfile" ->
+        HiveSerDe(
+          inputFormat = Option("org.apache.hadoop.hive.ql.io.RCFileInputFormat"),
+          outputFormat = Option("org.apache.hadoop.hive.ql.io.RCFileOutputFormat"),
+          serde = Option(hiveConf.getVar(HiveConf.ConfVars.HIVEDEFAULTRCFILESERDE))),
+
+      "orc" ->
+        HiveSerDe(
+          inputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"),
+          outputFormat = Option("org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"),
+          serde = Option("org.apache.hadoop.hive.ql.io.orc.OrcSerde")),
+
+      "parquet" ->
+        HiveSerDe(
+          inputFormat = Option("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"),
+          outputFormat = Option("org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"),
+          serde = Option("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe")))
+
+    val key = source.toLowerCase match {
+      case _ if source.startsWith("org.apache.spark.sql.parquet") => "parquet"
+      case _ if source.startsWith("org.apache.spark.sql.orc") => "orc"
+      case _ => source.toLowerCase
     }
 
-    Option(serde)
+    serdeMap.get(key)
   }
 }
 
@@ -226,15 +216,15 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
       processDatabaseAndTableName(database, tableIdent.table)
     }
 
-    val tableProperties = new scala.collection.mutable.HashMap[String, String]
+    val tableProperties = new mutable.HashMap[String, String]
     tableProperties.put("spark.sql.sources.provider", provider)
 
     // Saves optional user specified schema.  Serialized JSON schema string may be too long to be
     // stored into a single metastore SerDe property.  In this case, we split the JSON string and
     // store each part as a separate SerDe property.
-    if (userSpecifiedSchema.isDefined) {
+    userSpecifiedSchema.foreach { schema =>
       val threshold = conf.schemaStringLengthThreshold
-      val schemaJsonString = userSpecifiedSchema.get.json
+      val schemaJsonString = schema.json
       // Split the JSON string.
       val parts = schemaJsonString.grouped(threshold).toSeq
       tableProperties.put("spark.sql.sources.schema.numParts", parts.size.toString)
@@ -256,7 +246,7 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
         // The table does not have a specified schema, which means that the schema will be inferred
         // when we load the table. So, we are not expecting partition columns and we will discover
         // partitions when we load the table. However, if there are specified partition columns,
-        // we simplily ignore them and provide a warning message..
+        // we simply ignore them and provide a warning message.
         logWarning(
           s"The schema and partitions of table $tableIdent will be inferred when it is loaded. " +
             s"Specified partition columns (${partitionColumns.mkString(",")}) will be ignored.")
@@ -272,61 +262,92 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
       ManagedTable
     }
 
-    val hiveTable = HiveSerDe.sourceToSerDe(provider, hive.hiveconf, false) match {
-      case Some(hiveSerDe) if conf.writeSchemaToHiveMetastore =>
-        // get the schema from the data source
-        val ds = ResolvedDataSource(hive, userSpecifiedSchema, partitionColumns, provider, options)
-        ds.relation match {
-          case fs: HadoopFsRelation if fs.paths.length == 1 =>
-            def schemaToHiveColumn(schema: StructType): Seq[HiveColumn] = {
-              schema.map( field => HiveColumn(
-                name = field.name,
-                hiveType = HiveMetastoreTypes.toMetastoreType(field.dataType),
-                comment = "")
-              )
-            }
-            // get the partition columns
-            val parts = schemaToHiveColumn(fs.partitionColumns)
-            val partSet = parts.toSet
-            // remove the partition columns from the relation schema
-            val columns = schemaToHiveColumn(ds.relation.schema).filterNot(partSet.contains)
+    val maybeSerDe = HiveSerDe.sourceToSerDe(provider, hive.hiveconf)
+    val dataSource = ResolvedDataSource(
+      hive, userSpecifiedSchema, partitionColumns, provider, options)
 
-            HiveTable(
-              specifiedDatabase = Option(dbName),
-              name = tblName,
-              schema = columns,
-              partitionColumns = parts,
-              tableType = tableType,
-              properties = tableProperties.toMap,
-              serdeProperties = options,
-              location = Some(fs.paths.head),
-              viewText = None, // TODO We need to place the SQL string here.
-              inputFormat = hiveSerDe.inputFormat,
-              outputFormat = hiveSerDe.outputFormat,
-              serde = hiveSerDe.serde)
-          case fs: HadoopFsRelation =>
-            throw new AnalysisException(
-              """Only a single location support for HadoopFSRelation when write the metadata
-                |into the Hive Metastore, set spark.sql.hive.writeDataSourceSchema=false
-                |for not conform to Hive""".stripMargin)
-          case _ =>
-            throw new AnalysisException(
-              """Unable to write the Non HadoopFSRelation DataSource meta data
-                |into the Hive Metastore, set spark.sql.hive.writeDataSourceSchema=false
-                |for not conform to Hive""".stripMargin)
+    def newSparkSQLSpecificMetastoreTable(): HiveTable = {
+      HiveTable(
+        specifiedDatabase = Option(dbName),
+        name = tblName,
+        schema = Seq.empty,
+        partitionColumns = metastorePartitionColumns,
+        tableType = tableType,
+        properties = tableProperties.toMap,
+        serdeProperties = options)
+    }
+
+    def newHiveCompatibleMetastoreTable(relation: HadoopFsRelation, serde: HiveSerDe): HiveTable = {
+      def schemaToHiveColumn(schema: StructType): Seq[HiveColumn] = {
+        schema.map { field =>
+          HiveColumn(
+            name = field.name,
+            hiveType = HiveMetastoreTypes.toMetastoreType(field.dataType),
+            comment = "")
         }
-      case other =>
-        if (other.isEmpty) {
-          logWarning(s"Unable to find the SerDe info for $provider")
+      }
+
+      val partitionColumns = schemaToHiveColumn(relation.partitionColumns)
+      val dataColumns = schemaToHiveColumn(relation.schema).filterNot(partitionColumns.contains)
+
+      HiveTable(
+        specifiedDatabase = Option(dbName),
+        name = tblName,
+        schema = dataColumns,
+        partitionColumns = partitionColumns,
+        tableType = tableType,
+        properties = tableProperties.toMap,
+        serdeProperties = options,
+        location = Some(relation.paths.head),
+        viewText = None, // TODO We need to place the SQL string here.
+        inputFormat = serde.inputFormat,
+        outputFormat = serde.outputFormat,
+        serde = serde.serde)
+    }
+
+    // TODO: Support persisting partitioned data source relations in Hive compatible format
+    val hiveTable = (maybeSerDe, dataSource.relation) match {
+      case (Some(serde), relation: HadoopFsRelation)
+          if relation.paths.length == 1 && relation.partitionColumns.isEmpty =>
+        logInfo {
+          "Persisting data source relation with a single input path into Hive metastore in Hive " +
+            s"compatible format.  Input path: ${relation.paths.head}"
         }
-        HiveTable(
-          specifiedDatabase = Option(dbName),
-          name = tblName,
-          schema = Seq.empty,
-          partitionColumns = metastorePartitionColumns,
-          tableType = tableType,
-          properties = tableProperties.toMap,
-          serdeProperties = options)
+        newHiveCompatibleMetastoreTable(relation, serde)
+
+      case (Some(serde), relation: HadoopFsRelation) if relation.partitionColumns.nonEmpty =>
+        logWarning {
+          val paths = relation.paths.mkString(", ")
+          "Persisting partitioned data source relation into Hive metastore in " +
+            s"Spark SQL specific format, which is NOT compatible with Hive.  Input path(s): " +
+            paths.mkString("\n", "\n", "")
+        }
+        newSparkSQLSpecificMetastoreTable()
+
+      case (Some(serde), relation: HadoopFsRelation) =>
+        logWarning {
+          val paths = relation.paths.mkString(", ")
+          "Persisting data source relation with multiple input paths into Hive metastore in " +
+            s"Spark SQL specific format, which is NOT compatible with Hive.  Input paths: " +
+            paths.mkString("\n", "\n", "")
+        }
+        newSparkSQLSpecificMetastoreTable()
+
+      case (Some(serde), _) =>
+        logWarning {
+          s"Data source relation is not a ${classOf[HadoopFsRelation].getSimpleName}. " +
+            "Persisting it into Hive metastore in Spark SQL specific format, " +
+            "which is NOT compatible with Hive."
+        }
+        newSparkSQLSpecificMetastoreTable()
+
+      case _ =>
+        logWarning {
+          s"Couldn't find corresponding Hive SerDe for data source provider $provider. " +
+            "Persisting data source relation into Hive metastore in Spark SQL specific format, " +
+            "which is NOT compatible with Hive."
+        }
+        newSparkSQLSpecificMetastoreTable()
     }
 
     client.createTable(hiveTable)
@@ -575,7 +596,7 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
       case p: LogicalPlan if !p.childrenResolved => p
       case p: LogicalPlan if p.resolved => p
       case p @ CreateTableAsSelect(table, child, allowExisting) =>
-        val schema = if (table.schema.size > 0) {
+        val schema = if (table.schema.nonEmpty) {
           table.schema
         } else {
           child.output.map {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveQl.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.ql.session.SessionState
 
 import org.apache.spark.Logging
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
@@ -257,8 +258,8 @@ private[hive] object HiveQl extends Logging {
   /**
    * Returns the HiveConf
    */
-  private[this] def hiveConf(): HiveConf = {
-    val ss = SessionState.get() // SessionState is lazy initializaion, it can be null here
+  private[this] def hiveConf: HiveConf = {
+    val ss = SessionState.get() // SessionState is lazy initialization, it can be null here
     if (ss == null) {
       new HiveConf()
     } else {
@@ -608,7 +609,11 @@ https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C
       // default storage type abbreviation (e.g. RCFile, ORC, PARQUET etc.)
       val defaultStorageType = hiveConf.getVar(HiveConf.ConfVars.HIVEDEFAULTFILEFORMAT)
       // handle the default format for the storage type abbreviation
-      val hiveSerDe = HiveSerDe.sourceToSerDe(defaultStorageType, hiveConf, true).get
+      val hiveSerDe = HiveSerDe.sourceToSerDe(defaultStorageType, hiveConf).getOrElse {
+        HiveSerDe(
+          inputFormat = Option("org.apache.hadoop.mapred.TextInputFormat"),
+          outputFormat = Option("org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat"))
+      }
 
       hiveSerDe.inputFormat.foreach(f => tableDesc = tableDesc.copy(inputFormat = Some(f)))
       hiveSerDe.outputFormat.foreach(f => tableDesc = tableDesc.copy(outputFormat = Some(f)))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -74,29 +74,6 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils {
     checkAnswer(query, Row(1, 1) :: Row(1, 2) :: Row(1, 3) :: Nil)
   }
 
-  test("SPARK-7550: Support setting the right schema & serde when writing to Hive Metastore") {
-    val df = Seq((1, 1)).toDF("c1", "c2")
-
-    // test writing orc table via data source api, and read it in Hive
-    df.write.format("orc").saveAsTable("spark_7550_orc")
-    checkAnswer(sql("select * from spark_7550_orc"), Row(1, 1) :: Nil)   // run with spark
-    val hiveResult1 = runSqlHive("select * from spark_7550_orc limit 2") // run with hive
-    assert(hiveResult1.length === 1)
-    assert(hiveResult1(0) === "1\t1")
-
-    // test writing parquet table via data source api, and read it in Hive
-    df.write.format("parquet").saveAsTable("spark_7550_parquet")
-    checkAnswer(sql("select * from spark_7550_parquet"), Row(1, 1) :: Nil)   // run with spark
-    val hiveResult2 = runSqlHive("select * from spark_7550_parquet limit 2") // run with hive
-    assert(hiveResult2.length === 1)
-    assert(hiveResult2(0) === "1\t1")
-
-    // test writing json table via data source api
-    // will not throw exception, but will log warning,
-    // as Hive is not able to load data from this table
-    df.write.format("json").saveAsTable("spark_7550_json")
-  }
-
   test("SPARK-6851: Self-joined converted parquet tables") {
     val orders = Seq(
       Order(1, "Atlas", "MTB", 234, "2015-01-07", "John D", "Pacifica", "CA", 20151),


### PR DESCRIPTION
Major changes:
- Remove `spark.sql.hive.writeDataSourceSchema`.
- Always persist the data source relation in Hive compatible format when possible, and give warning logs to indicate why we can't do this.
- Now we ony persist non-partitioned `HadoopFsRelation` with a single input path. The original PR only persists partition columns information without adding individual partitions, so persisting partitioned tables actually doesn't work.
- Refactor test cases.
